### PR TITLE
ci: split up the GitHub actions into different files

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,51 @@
+name: Master
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  assemble:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 1.8
+    - name: run assemble
+      run: ./gradlew assemble
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 1.8
+    - name: run testDebugUnitTest
+      run: ./gradlew testDebugUnitTest
+    - name: run jacocoTestReport
+      run: ./gradlew jacocoTestReport
+    - uses: codecov/codecov-action@v1.0.14
+
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 1.8
+    - name: run ktlintCheck
+      run: ./gradlew ktlintCheck
+    - name: run lintDebug
+      run: ./gradlew lintDebug
+    - name: run detekt
+      run: ./gradlew detekt
+    - name: upload lint results
+      uses: actions/upload-artifact@v2
+      with:
+        name: lint
+        path: build/reports/

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -1,12 +1,8 @@
-name: Android CI
+name: Pre-Merge
 
 on:
-  push:
-    branches: [ master ]
   pull_request_target:
-    branches: [ master ]
-  release:
-    types: [ published ]
+    branches: [ '*' ]
 
 jobs:
   assemble:
@@ -41,16 +37,6 @@ jobs:
     - name: run jacocoTestReport
       run: ./gradlew jacocoTestReport
     - uses: codecov/codecov-action@v1.0.14
-    - name: upload test results
-      uses: actions/upload-artifact@v2
-      with:
-        name: tests
-        path: app/build/reports/
-    - name: upload test xml
-      uses: actions/upload-artifact@v2
-      with:
-        name: test_xml
-        path: app/build/test-results/
 
   analyze:
     runs-on: ubuntu-latest
@@ -68,22 +54,16 @@ jobs:
       run: ./gradlew ktlintCheck
     - name: run lintDebug
       run: ./gradlew lintDebug
+    - name: run detekt
+      run: ./gradlew detekt
     - name: upload lint results
       uses: actions/upload-artifact@v2
       with:
         name: lint
-        path: app/build/reports/
-    - name: run detekt
-      run: ./gradlew detekt
-    - name: upload detekt results
-      uses: actions/upload-artifact@v2
-      with:
-        name: detekt
         path: build/reports/
 
   danger:
     needs: [ test, analyze ]
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -110,17 +90,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: lint
-        path: app/build/reports/
-    - name: download detekt results
-      uses: actions/download-artifact@v2
-      with:
-        name: detekt
         path: build/reports/
-    - name: download test results
-      uses: actions/download-artifact@v2
-      with:
-        name: test_xml
-        path: app/build/test-results/
     - uses: MeilCli/danger-action@v5.0.0
       with:
         plugins_file: 'Gemfile'
@@ -129,26 +99,3 @@ jobs:
         danger_id: 'danger-ci'
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_API_TOKEN }}
- 
-  deploy:
-    needs: [ assemble, test, analyze ]
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        fetch-depth: 0
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1.4.3
-      with:
-        java-version: 1.8
-    - name: Fetch tags
-      run: git fetch origin 'refs/tags/*:refs/tags/*'
-    - name: run assemble
-      run: ./gradlew assemble
-    - name: Set env
-      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
-    - name: Publish
-      run: ./gradlew publish -PbintrayUser=${{ secrets.BINTRAY_USER_ID }} -PbintrayKey=${{ secrets.BINTRAY_API_KEY }} -PpublishVersion=${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 1.8
+    - name: Fetch tags
+      run: git fetch origin 'refs/tags/*:refs/tags/*'
+    - name: run assemble
+      run: ./gradlew assemble
+    - name: run testDebugUnitTest
+      run: ./gradlew testDebugUnitTest
+    - name: Set env
+      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
+    - name: Publish
+      run: ./gradlew publish -PbintrayUser=${{ secrets.BINTRAY_USER_ID }} -PbintrayKey=${{ secrets.BINTRAY_API_KEY }} -PpublishVersion=${{ env.RELEASE_VERSION }}

--- a/Dangerfile
+++ b/Dangerfile
@@ -12,13 +12,11 @@ warn("This PR cannot be merged yet.", sticky: false) unless can_merge
 github.dismiss_out_of_range_messages
 
 # AndroidLint
-lint_dir = "**/reports/lint-results*.xml"
-Dir[lint_dir].each do |file_name|
-  android_lint.skip_gradle_task = true
-  android_lint.filtering = true
-  android_lint.report_file = file_name
-  android_lint.lint(inline_mode: true)
-end
+android_lint.skip_gradle_task = true
+android_lint.report_file = 'build/reports/lint-results.xml'
+android_lint.gradle_task = "lintDebug"
+android_lint.filtering = true
+android_lint.lint(inline_mode: true)
 
 # CheckstyleFormat
 checkstyle_format.base_path = Dir.pwd

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AndroidTemplate
 Template repository to pre-configure Android projects with various tools.
 
-## Tools  
+## Tools
 List of tools that will be installed or have configuration provided.  
 
 * Commitlint  


### PR DESCRIPTION
Instead of having all GitHub actions inside an `android.yml` split it up based on what the actions
being performed are, making it easier to manage in the future