### PR TITLE
ci: update github actions to remove pull_request_target

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -44,8 +44,3 @@ jobs:
       run: ./gradlew lintDebug
     - name: run detekt
       run: ./gradlew detekt
-    - name: upload lint results
-      uses: actions/upload-artifact@v2
-      with:
-        name: lint
-        path: build/reports/

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -1,18 +1,13 @@
 name: Pre-Merge
 
 on:
-  pull_request_target:
-    branches: [ '*' ]
+  pull_request:
 
 jobs:
   assemble:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        fetch-depth: 0
     - name: set up JDK 1.8
       uses: actions/setup-java@v1.4.3
       with:
@@ -24,10 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        fetch-depth: 0
     - name: set up JDK 1.8
       uses: actions/setup-java@v1.4.3
       with:
@@ -38,20 +29,25 @@ jobs:
       run: ./gradlew jacocoTestReport
     - uses: codecov/codecov-action@v1.2.1
 
-  analyze:
+  ktlint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        fetch-depth: 0
     - name: set up JDK 1.8
       uses: actions/setup-java@v1.4.3
       with:
         java-version: 1.8
     - name: run ktlintCheck
       run: ./gradlew ktlintCheck
+
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 1.8
     - name: run lintDebug
       run: ./gradlew lintDebug
     - name: run detekt
@@ -67,14 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        fetch-depth: 0
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1.4.3
-      with:
-        java-version: 1.8
     - uses: actions/setup-ruby@v1.1.2
       with:
         ruby-version: '2.6'


### PR DESCRIPTION
Remove the pull_request_target since it has some security implications, instead use normal pull_request.