### PR TITLE
feat: run ktlint on pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+./gradlew ktlintCheck


### PR DESCRIPTION
## Description of the change
When trying to push up code use Husky to run ktlintCheck first to save time when running on CI

Closes #77 

## Reason for the change
Ensure that Android projects run `ktlintCheck` before they push up the code, so that the CI doesn't build needlessly.
