### PR TITLE
feat: dangerfile check pr description

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,8 @@
+def pr_matches_body?
+  template = File.read(".github/pull_request_template.md")
+  github.pr_body.gsub(/\s+/, "").eql? template.gsub(/\s+/, "")
+end
+
 # General
 github.dismiss_out_of_range_messages
 
@@ -5,12 +10,13 @@ github.dismiss_out_of_range_messages
 failure "Please provide a title for the pull request" if github.pr_title.length < 5
 
 # PR body
-failure "Please provide a summary in the pull request description" if github.pr_body.length < 5
+failure "Please provide a description for the pull request" if github.pr_body.length < 5
+failure "Please fill in the pull request template" if pr_matches_body?
 
 # PR other
 warn "This PR does not have any assignees yet." unless github.pr_json["assignee"]
-warn "Big PR" if git.lines_of_code > 500
 warn "PR is classed as Work in Progress" if github.pr_title.include? "[WIP]"
+warn "Big PR" if git.lines_of_code > 500
 
 # AndroidLint
 lint_dir = "**/reports/lint-results*.xml"

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,15 +1,16 @@
-# Make it more obvious that a PR is a work in progress and shouldn't be merged yet
-warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
-
-# Warn when there is a big PR
-warn("Big PR") if git.lines_of_code > 500
-
 # General
-failure "Please provide a summary in the Pull Request description" if github.pr_body.length < 5
-warn "This PR does not have any assignees yet." unless github.pr_json["assignee"]
-can_merge = github.pr_json["mergeable"]
-warn("This PR cannot be merged yet.", sticky: false) unless can_merge
 github.dismiss_out_of_range_messages
+
+# PR title
+failure "Please provide a title for the pull request" if github.pr_title.length < 5
+
+# PR body
+failure "Please provide a summary in the pull request description" if github.pr_body.length < 5
+
+# PR other
+warn "This PR does not have any assignees yet." unless github.pr_json["assignee"]
+warn "Big PR" if git.lines_of_code > 500
+warn "PR is classed as Work in Progress" if github.pr_title.include? "[WIP]"
 
 # AndroidLint
 lint_dir = "**/reports/lint-results*.xml"


### PR DESCRIPTION
## Description of the change
Update Danger so it reports a warning if the pull request body is the same as the template.

Closes #86

## Reason for the change
Seeing a pull request description which is just the template is frustrating and shows lazy developers, now they can be shamed with Danger!